### PR TITLE
[#28] 존재하지 않는 API 요청이 static resource로 처리됨

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
+  web:
+    resources:
+      add-mappings: false # 정적 리소스 서빙 안함
 
 cloud:
   aws:


### PR DESCRIPTION
## 문제 설명
존재하지 않는 /api/** 경로 요청 시 컨트롤러 404(NoHandlerFoundException)가 아닌
static resource 처리로 인해 NoResourceFoundException 발생(버그 상세 내용: #28 참고)

## 원인
Boot 기본 정적 리소스 자동 서빙(ResourceHandlerMapping) 때문에, 컨트롤러 매핑 실패 시 
정적 리소스 핸들러가 요청을 처리하려고 시도함.

## 해결 방법
1. 정적 리소스 매핑이 활성화되어 있으면 ResourceHttpRequestHandler에서 NoResourceFoundException이 발생할 수 있음.
2. 정적 리소스 매핑을 비활성화 시킨다면 상태에서 컨트롤러 매핑이 없을시 NoHandlerFoundException이 발생하고
    이를 GlobalExceptionHandler에서 404 JSON으로 응답하도록 한다.

` 
web:
resources:
add-mappings: false
` 설정 추가
=> 백엔드만 제공하므로 설정에서 정적 리소스 서빙을 하지 않아도 무방