### PR TITLE
[#30] 관심 작품 등록/해제/목록보기

### DIFF
--- a/src/main/java/com/creatorhub/constant/ErrorCode.java
+++ b/src/main/java/com/creatorhub/constant/ErrorCode.java
@@ -11,8 +11,13 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "M003", "비밀번호가 올바르지 않습니다."),
 
     // Creator 관련 에러
-    ALREADY_CREATOR(HttpStatus.CONFLICT, "C001", "이미 존재하는 작가입니다."),
-    CREATOR_NOT_FOUND(HttpStatus.NOT_FOUND, "C002", "존재하는 않는 작가입니다."),
+    ALREADY_CREATOR(HttpStatus.CONFLICT, "MC001", "이미 존재하는 작가입니다."),
+    CREATOR_NOT_FOUND(HttpStatus.NOT_FOUND, "MC002", "존재하는 않는 작가입니다."),
+
+    // Creation 관련 에러
+    ALREADY_CREATION(HttpStatus.CONFLICT, "C001", "이미 존재하는 작품입니다."),
+    CREATION_NOT_FOUND(HttpStatus.NOT_FOUND, "C002", "존재하는 않는 작품입니다."),
+    CREATION_FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "관심 작품으로 등록되어있지 않습니다."),
 
     // Authorization 관련 에러
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "A001", "접근이 제한되었습니다."),

--- a/src/main/java/com/creatorhub/controller/CreationFavoriteController.java
+++ b/src/main/java/com/creatorhub/controller/CreationFavoriteController.java
@@ -1,0 +1,62 @@
+package com.creatorhub.controller;
+
+
+import com.creatorhub.dto.CreationFavoriteResponse;
+import com.creatorhub.dto.FavoriteCreationItem;
+import com.creatorhub.security.auth.CustomUserPrincipal;
+import com.creatorhub.service.CreationFavoriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/creations")
+public class CreationFavoriteController {
+    private final CreationFavoriteService creationFavoriteService;
+
+    /**
+     * 관심 등록
+     */
+    @PostMapping("/{creationId}/favorite")
+    public ResponseEntity<CreationFavoriteResponse> favorite(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long creationId
+    ) {
+        CreationFavoriteResponse creationFavoriteResponse =
+                creationFavoriteService.favorite(principal.id(), creationId);
+
+        return ResponseEntity.ok(creationFavoriteResponse);
+    }
+
+    /**
+     * 관심 해제
+     */
+    @DeleteMapping("/{creationId}/favorite")
+    public ResponseEntity<CreationFavoriteResponse> unfavorite(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long creationId
+    ) {
+        CreationFavoriteResponse creationFavoriteResponse =
+                creationFavoriteService.unfavorite(principal.id(), creationId);
+
+        return ResponseEntity.ok(creationFavoriteResponse);
+    }
+
+    /**
+     * 내 관심작품 목록
+     */
+    @GetMapping("/me/favorites")
+    public ResponseEntity<Page<FavoriteCreationItem>> myFavorites(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            Pageable pageable
+    ) {
+        Page<FavoriteCreationItem> favoriteCreationItem =
+                creationFavoriteService.getMyFavorites(principal.id(), pageable);
+
+        return ResponseEntity.ok(favoriteCreationItem);
+    }
+}

--- a/src/main/java/com/creatorhub/dto/CreationFavoriteResponse.java
+++ b/src/main/java/com/creatorhub/dto/CreationFavoriteResponse.java
@@ -1,0 +1,13 @@
+package com.creatorhub.dto;
+
+public record CreationFavoriteResponse(
+        Long creationId,
+        boolean favorited
+) {
+    public static CreationFavoriteResponse of(
+            Long creationId,
+            boolean favorited
+    ) {
+        return new CreationFavoriteResponse(creationId, favorited);
+    }
+}

--- a/src/main/java/com/creatorhub/dto/FavoriteCreationItem.java
+++ b/src/main/java/com/creatorhub/dto/FavoriteCreationItem.java
@@ -1,0 +1,13 @@
+package com.creatorhub.dto;
+
+import java.time.LocalDateTime;
+
+public record FavoriteCreationItem(
+        Long creationId,
+        String title,
+        String plot,
+        boolean isPublic,
+        Integer favoriteCount,
+        LocalDateTime favoritedAt
+) {
+}

--- a/src/main/java/com/creatorhub/entity/Creation.java
+++ b/src/main/java/com/creatorhub/entity/Creation.java
@@ -49,6 +49,9 @@ public class Creation extends BaseEntity {
     @Column(nullable = false)
     private boolean isPublic;
 
+    @Column
+    private Integer favoriteCount;
+
     // 연재요일은 자주 바뀌지 않으므로 별도의 엔티티가 아닌 @ElementCollection사용
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
@@ -78,6 +81,7 @@ public class Creation extends BaseEntity {
         this.title = title;
         this.plot = plot;
         this.isPublic = isPublic;
+        this.favoriteCount = 0;
     }
 
     public static Creation create(Creator creator,
@@ -95,11 +99,6 @@ public class Creation extends BaseEntity {
                 .isPublic(isPublic)
                 .build();
     }
-
-    public void publish() {
-        this.isPublic = true;
-    }
-    public void unpublish() { this.isPublic = false; }
 
     public void addThumbnail(CreationThumbnail thumbnail) {
         this.creationThumbnails.add(thumbnail);

--- a/src/main/java/com/creatorhub/entity/CreationFavorite.java
+++ b/src/main/java/com/creatorhub/entity/CreationFavorite.java
@@ -1,0 +1,61 @@
+package com.creatorhub.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(
+        name = "creation_favorite",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_creation_favorite_member_creation",
+                columnNames = {"member_id", "creation_id"}
+        ),
+        indexes = {
+                // 내 관심작품 목록 조회 (최신순)
+                @Index(
+                        name = "idx_creation_favorite_member_created_at",
+                        columnList = "member_id, created_at"
+                ),
+                // 작품별 관심자 조회 (알림 대상 추출)
+                @Index(
+                        name = "idx_creation_favorite_creation",
+                        columnList = "creation_id"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE creation_favorite SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class CreationFavorite extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "creation_id", nullable = false)
+    private Creation creation;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private CreationFavorite(Member member, Creation creation) {
+        this.member = member;
+        this.creation = creation;
+    }
+
+    public static CreationFavorite create(Member member, Creation creation) {
+        return CreationFavorite.builder()
+                .member(member)
+                .creation(creation)
+                .build();
+    }
+}

--- a/src/main/java/com/creatorhub/exception/CreationException.java
+++ b/src/main/java/com/creatorhub/exception/CreationException.java
@@ -1,0 +1,19 @@
+package com.creatorhub.exception;
+
+import com.creatorhub.constant.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CreationException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CreationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CreationException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/creatorhub/exception/CreationNotFoundException.java
+++ b/src/main/java/com/creatorhub/exception/CreationNotFoundException.java
@@ -1,0 +1,14 @@
+package com.creatorhub.exception;
+
+import com.creatorhub.constant.ErrorCode;
+
+public class CreationNotFoundException extends CreatorException {
+
+    public CreationNotFoundException() {
+        super(ErrorCode.CREATION_NOT_FOUND);
+    }
+
+    public CreationNotFoundException(String message) {
+        super(ErrorCode.CREATION_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/creatorhub/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/creatorhub/exception/GlobalExceptionHandler.java
@@ -52,6 +52,24 @@ public class GlobalExceptionHandler {
                 .body(errorResponse);
     }
 
+    /**
+     * Creation 관련 예외 처리
+     */
+    @ExceptionHandler(CreationException.class)
+    public ResponseEntity<ErrorResponse> handleCreationException(
+            CreationException ex,
+            HttpServletRequest request) {
+
+        log.warn("CreationException occurred - Message: {}", ex.getMessage());
+
+        ErrorResponse errorResponse =
+                ErrorResponse.of(ex.getErrorCode(), request.getRequestURI());
+
+        return ResponseEntity
+                .status(ex.getErrorCode().getHttpStatus())
+                .body(errorResponse);
+    }
+
 
     /**
      * 요청 데이터 검증 오류 처리 (@Valid 실패)

--- a/src/main/java/com/creatorhub/repository/CreationFavoriteRepository.java
+++ b/src/main/java/com/creatorhub/repository/CreationFavoriteRepository.java
@@ -1,0 +1,11 @@
+package com.creatorhub.repository;
+
+import com.creatorhub.entity.CreationFavorite;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreationFavoriteRepository extends JpaRepository<CreationFavorite, Long> {
+    Page<CreationFavorite> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+    int deleteByMemberIdAndCreationId(Long memberId, Long creationId);
+}

--- a/src/main/java/com/creatorhub/repository/CreationRepository.java
+++ b/src/main/java/com/creatorhub/repository/CreationRepository.java
@@ -2,6 +2,28 @@ package com.creatorhub.repository;
 
 import com.creatorhub.entity.Creation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface CreationRepository  extends JpaRepository<Creation, Long> {
+public interface CreationRepository extends JpaRepository<Creation, Long> {
+
+    // JPA 엔티티 방식으로 작업시 읽기 -> 계산 -> 쓰기 방식으로 진행되기 때문에 동시 요청시 favoriteCount값이 -1이 될 수 있음
+    // 이를 방지하기 위해 UPDATE 쿼리에서 증감 연산을 수행해 DB에서 원자성을 보장하도록 구현
+    // 동시에 favoriteCount값이 0 아래로 더 이상 감소되지 않도록 처리
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Creation c
+           SET c.favoriteCount =
+               CASE
+                   WHEN :delta < 0 AND COALESCE(c.favoriteCount, 0) <= 0
+                       THEN 0
+                   ELSE COALESCE(c.favoriteCount, 0) + :delta
+               END
+         WHERE c.id = :creationId
+    """)
+    void updateFavoriteCount(@Param("creationId") Long creationId,
+                                  @Param("delta") int delta);
+
 }
+

--- a/src/main/java/com/creatorhub/service/CreationFavoriteService.java
+++ b/src/main/java/com/creatorhub/service/CreationFavoriteService.java
@@ -1,0 +1,87 @@
+package com.creatorhub.service;
+
+import com.creatorhub.dto.CreationFavoriteResponse;
+import com.creatorhub.dto.FavoriteCreationItem;
+import com.creatorhub.entity.Creation;
+import com.creatorhub.entity.CreationFavorite;
+import com.creatorhub.entity.Member;
+import com.creatorhub.exception.CreationNotFoundException;
+import com.creatorhub.exception.MemberNotFoundException;
+import com.creatorhub.repository.CreationFavoriteRepository;
+import com.creatorhub.repository.CreationRepository;
+import com.creatorhub.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CreationFavoriteService {
+    private final CreationFavoriteRepository creationFavoriteRepository;
+    private final CreationRepository creationRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 관심 등록
+     */
+    @Transactional
+    public CreationFavoriteResponse favorite(Long memberId, Long creationId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Creation creation = creationRepository.findById(creationId)
+                .orElseThrow(CreationNotFoundException::new);
+
+        // 유니크 + 예외로 멱등 처리
+        try {
+            // flush로 insert를 즉시 실행해 유니크(중복) 실패를 여기서 확정
+            creationFavoriteRepository.saveAndFlush(CreationFavorite.create(member, creation));
+        } catch (DataIntegrityViolationException e) {
+            return CreationFavoriteResponse.of(creationId, true);
+        }
+
+        creationRepository.updateFavoriteCount(creationId, 1);
+
+        return CreationFavoriteResponse.of(creationId, true);
+    }
+
+    /**
+     * 관심 해제
+     */
+    @Transactional
+    public CreationFavoriteResponse unfavorite(Long memberId, Long creationId) {
+        // delete row count 기반 멱등 처리 (동시성에서도 count 정합성 보장)
+        int deleted = creationFavoriteRepository
+                .deleteByMemberIdAndCreationId(memberId, creationId);
+
+        if (deleted > 0) {
+            creationRepository.updateFavoriteCount(creationId, -1);
+        }
+
+        return CreationFavoriteResponse.of(creationId, false);
+    }
+
+    /**
+     * 내 관심작품 목록 (최신 관심순)
+     */
+    public Page<FavoriteCreationItem> getMyFavorites(Long memberId, Pageable pageable) {
+        return creationFavoriteRepository.findByMemberIdOrderByCreatedAtDesc(memberId, pageable)
+                .map(cf -> {
+                    Creation c = cf.getCreation();
+                    return new FavoriteCreationItem(
+                            c.getId(),
+                            c.getTitle(),
+                            c.getPlot(),
+                            c.isPublic(),
+                            c.getFavoriteCount(),
+                            cf.getCreatedAt()
+                    );
+                });
+    }
+
+}


### PR DESCRIPTION
## 변경 내용
- 관심 작품 등록/삭제 로직의 멱등 처리 개선
- 동시성 상황에서 정합성 유지 로직 보완

## 배경
해당 작업이 feature/22 브랜치에 머지되어,
main 브랜치에 반영하기 위해 PR을 생성했습니다.

- 관련 PR: https://github.com/f-lab-edu/creatorhub-server/pull/33